### PR TITLE
Image path corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Welcome to Open-Source-Programs👋
 
 <p align="center">
-<img src="https://github.com/prathimacode-hub/prathimacode-hub/blob/main/CoverPhotos/Open-Source-Programs.png"></a>
+<img src="https://raw.githubusercontent.com/prathimacode-hub/prathimacode-hub/main/CoverPhotos/Open-Source-Programs.png">
 </p>
 <p align="center">
 <a href="https://github.com/prathimacode-hub"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat&logo=github"></a> 
@@ -95,8 +95,7 @@ This project follows the [MIT License](https://github.com/prathimacode-hub/Open-
 
 <h2>🙂 Project Admin</h2>
 
-<a href="https://github.com/prathimacode-hub"><img src="https://github.com/prathimacode-hub/prathimacode-hub/blob/main/Prathima%20updated%20profile%20pic.jpg" width=100px height=100px /></a>
-| :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+<a href="https://github.com/prathimacode-hub"><img src="https://avatars.githubusercontent.com/u/74645302?v=4" width=100px height=100px /></a>
 
 
 ![Visitor Count](https://profile-counter.glitch.me/{prathimacode-hub}/count.svg)


### PR DESCRIPTION
Fixes #1 

- [x]     **Cover and Project Admin**'s images are corrected and visible.
- [x]     `</a>` near to the **Cover Image** removed.
- [x]     Unnecessary **dashed line** in-between Project Admin's image and Visitors count are removed.

# After
![After](https://user-images.githubusercontent.com/83589431/148662896-7e9e7d87-ed9e-467b-b3fa-3904b2ca2726.png)

# Before
![Untitled](https://user-images.githubusercontent.com/83589431/148662931-066f0537-4a8b-4047-864d-a5a741a618ae.png)

